### PR TITLE
DIVAFT: Unlock (Extra) Extreme

### DIFF
--- a/patches/xml/HatsuneMiku_ProjectDIVAFutureTone-Orbis.xml
+++ b/patches/xml/HatsuneMiku_ProjectDIVAFutureTone-Orbis.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA08026</ID>
+        <ID>CUSA08053</ID>
+        <ID>CUSA06093</ID>
+        <ID>CUSA06211</ID>
+        <ID>CUSA05030</ID>
+        <ID>CUSA03828</ID>
+    </TitleID>
+    <Metadata Title="Hatsune Miku: Project DIVA Future Tone"
+              Name="Unlock (Extra) Extreme"
+              Author="M&amp;M, Stewie10"
+              PatchVer="1.0"
+              AppVer="mask"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="mask" Address="8A 87 19 01 00 00 C3" Value="b001c390909090"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
Allows you to access the (Extra) Extreme difficulty even if you haven't beaten Hard.

(look at difficulty select in top right)
Before:
![Screenshot 2024-08-28 08-57-13](https://github.com/user-attachments/assets/648698ec-b711-42e9-8692-ce3073b4d6b3)
After:
![Screenshot_2024-08-28_08-50-33](https://github.com/user-attachments/assets/2e37dbc3-09da-47fc-83f6-41eef1348006)

Credits: @Stewie10 for finding the variable/flag