### PR TITLE
Red Dead Redemption 2: Disable Invisible Snipers (New Austin)

### DIFF
--- a/patches/xml/RedDeadRedemption2-Orbis.xml
+++ b/patches/xml/RedDeadRedemption2-Orbis.xml
@@ -32,10 +32,10 @@
               AppVer="mask"
               AppElf="eboot.bin">
         <PatchList>
-			<!-- SHOOT_SINGLE_BULLET_BETWEEN_COORDS -->
+            <!-- SHOOT_SINGLE_BULLET_BETWEEN_COORDS -->
             <Line Type="mask" Address="89 55 b8 c7 45 c0 00 00 00 00 c7 45 c8 00 00 00 00 c7 45 90 00 00 00 00" Value="9090909090" Offset="+24"/>
-			<!-- FIRE_SINGLE_BULLET - Patch works only on v01.00/v01.02 (Used for New Austin only in v01.00, used in all versions for Guarma) -->
-			<Line Type="mask" Address="03 90 90 90 90 90 48 8b 47 10 48 8b 38 e9" Value="48c7c000000000c39090909090909090" Offset="+6"/>
+            <!-- FIRE_SINGLE_BULLET - Patch works only on v01.00/v01.02 (Used for New Austin only in v01.00, used in all versions for Guarma) -->
+            <Line Type="mask" Address="03 90 90 90 90 90 48 8b 47 10 48 8b 38 e9" Value="48c7c000000000c39090909090909090" Offset="+6"/>
         </PatchList>
     </Metadata>
 </Patch>

--- a/patches/xml/RedDeadRedemption2-Orbis.xml
+++ b/patches/xml/RedDeadRedemption2-Orbis.xml
@@ -25,4 +25,17 @@
             <Line Type="bytes" Address="0x009b4f44" Value="909090909090"/>
         </PatchList>
     </Metadata>
+    <Metadata Title="Red Dead Redemption 2"
+              Name="Disable Invisible Snipers"
+              Author="SuleMareVientu"
+              PatchVer="1.0"
+              AppVer="mask"
+              AppElf="eboot.bin">
+        <PatchList>
+			<!-- SHOOT_SINGLE_BULLET_BETWEEN_COORDS -->
+            <Line Type="mask" Address="89 55 b8 c7 45 c0 00 00 00 00 c7 45 c8 00 00 00 00 c7 45 90 00 00 00 00" Value="9090909090" Offset="+24"/>
+			<!-- FIRE_SINGLE_BULLET - Patch works only on v01.00/v01.02 (Used for New Austin only in v01.00, used in all versions for Guarma) -->
+			<Line Type="mask" Address="03 90 90 90 90 90 48 8b 47 10 48 8b 38 e9" Value="48c7c000000000c39090909090909090" Offset="+6"/>
+        </PatchList>
+    </Metadata>
 </Patch>

--- a/patches/xml/ResidentEvil4Remake-Orbis.xml
+++ b/patches/xml/ResidentEvil4Remake-Orbis.xml
@@ -23,11 +23,11 @@
               AppVer="mask"
               AppElf="eboot.bin">
         <PatchList>
-			<Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780481700000000a03fc3"/>
+            <Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780481700000000a03fc3"/>
             <Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700000000a03fc3"/> <!-- 01.11 -->
         </PatchList>
     </Metadata>
-	<Metadata Title="Resident Evil 4 Remake"
+    <Metadata Title="Resident Evil 4 Remake"
               Name="Resolution Scale: 83%"
               Author="illusion"
               PatchVer="1.0"
@@ -35,7 +35,7 @@
               AppElf="eboot.bin">
         <PatchList>
             <Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c78048170000e17a543fc3"/>
-			<Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c78058170000e17a543fc3"/> <!-- 01.11 -->
+            <Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c78058170000e17a543fc3"/> <!-- 01.11 -->
         </PatchList>
     </Metadata>
     <Metadata Title="Resident Evil 4 Remake"
@@ -46,7 +46,7 @@
               AppElf="eboot.bin">
         <PatchList>
             <Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780481700001f852b3fc3"/>
-			<Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700001f852b3fc3"/> <!-- 01.11 -->
+            <Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700001f852b3fc3"/> <!-- 01.11 -->
         </PatchList>
     </Metadata>
     <Metadata Title="Resident Evil 4 Remake"
@@ -57,7 +57,7 @@
               AppElf="eboot.bin">
         <PatchList>
             <Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780481700000000003fc3"/>
-			<Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700000000003fc3"/> <!-- 01.11 -->
+            <Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700000000003fc3"/> <!-- 01.11 -->
         </PatchList>
     </Metadata>
     <Metadata Title="Resident Evil 4 Remake"
@@ -68,7 +68,7 @@
               AppElf="eboot.bin">
         <PatchList>
             <Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780481700000000803ec3"/>
-			<Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700000000803ec3"/> <!-- 01.11 -->
+            <Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700000000803ec3"/> <!-- 01.11 -->
         </PatchList>
     </Metadata>
 </Patch>

--- a/patches/xml/ResidentEvil4Remake-Orbis.xml
+++ b/patches/xml/ResidentEvil4Remake-Orbis.xml
@@ -17,6 +17,17 @@
         </PatchList>
     </Metadata>
     <Metadata Title="Resident Evil 4 Remake"
+              Name="Resolution Scale: 125% (Native 1080p)"
+              Author="illusion, SuleMareVientu"
+              PatchVer="1.0"
+              AppVer="mask"
+              AppElf="eboot.bin">
+        <PatchList>
+			<Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780481700000000a03fc3"/>
+            <Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700000000a03fc3"/> <!-- 01.11 -->
+        </PatchList>
+    </Metadata>
+	<Metadata Title="Resident Evil 4 Remake"
               Name="Resolution Scale: 83%"
               Author="illusion"
               PatchVer="1.0"
@@ -24,6 +35,7 @@
               AppElf="eboot.bin">
         <PatchList>
             <Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c78048170000e17a543fc3"/>
+			<Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c78058170000e17a543fc3"/> <!-- 01.11 -->
         </PatchList>
     </Metadata>
     <Metadata Title="Resident Evil 4 Remake"
@@ -34,6 +46,7 @@
               AppElf="eboot.bin">
         <PatchList>
             <Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780481700001f852b3fc3"/>
+			<Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700001f852b3fc3"/> <!-- 01.11 -->
         </PatchList>
     </Metadata>
     <Metadata Title="Resident Evil 4 Remake"
@@ -44,6 +57,7 @@
               AppElf="eboot.bin">
         <PatchList>
             <Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780481700000000003fc3"/>
+			<Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700000000003fc3"/> <!-- 01.11 -->
         </PatchList>
     </Metadata>
     <Metadata Title="Resident Evil 4 Remake"
@@ -54,6 +68,7 @@
               AppElf="eboot.bin">
         <PatchList>
             <Line Type="mask" Address="c5 fa 10 88 48 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780481700000000803ec3"/>
+			<Line Type="mask" Address="c5 fa 10 88 58 17 00 00 c5 f8 2e c8 75 ?? 7a ?? c3" Value="c780581700000000803ec3"/> <!-- 01.11 -->
         </PatchList>
     </Metadata>
 </Patch>


### PR DESCRIPTION
Mask patch to disable "invisible snipers" in the game. Akin to existing mods on PC, but this allows to explore New Austin as Arthur in v01.00.