### PR TITLE
Amnesia The Bunker: Turn off resolution scaling.

### DIFF
--- a/patches/xml/AlienIsolation-Orbis.xml
+++ b/patches/xml/AlienIsolation-Orbis.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
     <TitleID>
+        <ID>CUSA00362</ID>
         <ID>CUSA00363</ID>
     </TitleID>
     <Metadata Title="Alien: Isolation"

--- a/patches/xml/AmnesiaTheBunker-Orbis.xml
+++ b/patches/xml/AmnesiaTheBunker-Orbis.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA40994</ID>
+    </TitleID>
+    <Metadata Title="Amnesia: The Bunker"
+              Name="Turn OFF Resolution Scaling"
+              Author="Maelly Pooh"
+              PatchVer="1.0"
+              AppVer="01.81"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="byte32" Address="0x00A8A09C" Value="0x909090909090"/>
+        </PatchList>
+    </Metadata>
+</Patch>

--- a/patches/xml/ResidentEvil2-Orbis.xml
+++ b/patches/xml/ResidentEvil2-Orbis.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
     <TitleID>
+        <ID>CUSA09171</ID>
         <ID>CUSA09193</ID>
     </TitleID>
     <Metadata Title="Resident Evil 2"


### PR DESCRIPTION
Someone had to do it. In some instances it goes to 4XXp with nearest neightbor upscaling... With this the game should stay at a fixed resolution. 1080p on base PS4 I guess, and don't know about PS4 Pro. 