### PR TITLE
Mod Support Patch for Persona 3: Dancing in Moonlight, Persona 4: Dancing All Night, and Persona 5: Dancing in Starlight

### DIFF
--- a/patches/xml/Persona3Dancing-Orbis.xml
+++ b/patches/xml/Persona3Dancing-Orbis.xml
@@ -5,7 +5,7 @@
     </TitleID>
     <Metadata Title="Persona 3: Dancing in Moonlight"
             Name="Mod Support"
-            Note="A port of zarroboogs patch. \nhttps://github.com/zarroboogs/ppp \n\nHighest to lowest load priority: \n1. /data/p3d/bind/ (loose files) \n2. /data/p3d/mod.cpk \n3. /data/p3d/mod1.cpk \n4. /data/p3d/mod2.cpk \n5. /data/p3d/mod3.cpk \n6. /app0/data/mod.cpk"
+            Note="A port of zarroboogs' patch. \nhttps://github.com/zarroboogs/ppp \n\nHighest to lowest load priority: \n1. /data/p3d/bind/ (loose files) \n2. /data/p3d/mod.cpk \n3. /data/p3d/mod1.cpk \n4. /data/p3d/mod2.cpk \n5. /data/p3d/mod3.cpk \n6. /app0/data/mod.cpk"
             Author="zarroboogs, Ahtheerr, Danu"
             PatchVer="1.0"
             AppVer="01.00"

--- a/patches/xml/Persona3Dancing-Orbis.xml
+++ b/patches/xml/Persona3Dancing-Orbis.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA12636</ID>
+    </TitleID>
+    <Metadata Title="Persona 3: Dancing in Moonlight"
+            Name="Mod Support"
+            Note="A port of zarroboogs patch. \nhttps://github.com/zarroboogs/ppp \n\nHighest to lowest load priority: \n1. /data/p3d/bind/ (loose files) \n2. /data/p3d/mod.cpk \n3. /data/p3d/mod1.cpk \n4. /data/p3d/mod2.cpk \n5. /data/p3d/mod3.cpk \n6. /app0/data/mod.cpk"
+            Author="zarroboogs, Ahtheerr, Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0060b85c" Value="4d31f64c8d254a574400498d7c2404e8c000000085c07410418b342483feff740789c7e89cf7190049ffc64983fe08747a4983c420ebd34831db803c1a00740548ffc3ebf58a5c1aff80fb2f7407e8a1cd1900eb05e84adf1900e9be000000"/>
+            <Line Type="bytes" Address="0x0060b974" Value="e91affffff"/>
+            <Line Type="bytes" Address="0x00a50fb0" Value="ff0000102f646174612f7033642f62696e642f00"/>
+            <Line Type="bytes" Address="0x00a50fd0" Value="fe0000102f646174612f7033642f6d6f642e63706b00"/>
+            <Line Type="bytes" Address="0x00a50ff0" Value="fd0000102f646174612f7033642f6d6f64312e63706b0000"/>
+            <Line Type="bytes" Address="0x00a51010" Value="fc0000102f646174612f7033642f6d6f64322e63706b0000"/>
+            <Line Type="bytes" Address="0x00a51030" Value="fb0000102f646174612f7033642f6d6f64332e63706b0000"/>
+            <Line Type="bytes" Address="0x00a51050" Value="fa0000102f617070302f646174612f6d6f642e63706b0000"/>
+            <Line Type="bytes" Address="0x00a51070" Value="ffffffff2f617070302f646174612f7073342e63706b0000"/>
+            <Line Type="bytes" Address="0x00a51090" Value="ffffffff2f617070302f646174612f646174612e63706b00"/>
+            <Line Type="bytes" Address="0x00a510b4" Value="00000000000000000000000000"/>
+        </PatchList>
+    </Metadata>
+</Patch>

--- a/patches/xml/Persona4Dancing-Orbis.xml
+++ b/patches/xml/Persona4Dancing-Orbis.xml
@@ -5,7 +5,7 @@
     </TitleID>
     <Metadata Title="Persona 4: Dancing All Night"
             Name="Mod Support"
-            Note="A port of zarroboogs patch. \nhttps://github.com/zarroboogs/ppp \n\nHighest to lowest load priority: \n1. /data/p4d/bind/ (loose files) \n2. /data/p4d/mod.cpk \n3. /data/p4d/mod1.cpk \n4. /data/p4d/mod2.cpk \n5. /data/p4d/mod3.cpk \n6. /app0/data/mod.cpk"
+            Note="A port of zarroboogs' patch. \nhttps://github.com/zarroboogs/ppp \n\nHighest to lowest load priority: \n1. /data/p4d/bind/ (loose files) \n2. /data/p4d/mod.cpk \n3. /data/p4d/mod1.cpk \n4. /data/p4d/mod2.cpk \n5. /data/p4d/mod3.cpk \n6. /app0/data/mod.cpk"
             Author="zarroboogs, Ahtheerr, Danu"
             PatchVer="1.0"
             AppVer="01.00"

--- a/patches/xml/Persona4Dancing-Orbis.xml
+++ b/patches/xml/Persona4Dancing-Orbis.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA12380</ID>
+    </TitleID>
+    <Metadata Title="Persona 4: Dancing All Night"
+            Name="Mod Support"
+            Note="A port of zarroboogs patch. \nhttps://github.com/zarroboogs/ppp \n\nHighest to lowest load priority: \n1. /data/p4d/bind/ (loose files) \n2. /data/p4d/mod.cpk \n3. /data/p4d/mod1.cpk \n4. /data/p4d/mod2.cpk \n5. /data/p4d/mod3.cpk \n6. /app0/data/mod.cpk"
+            Author="zarroboogs, Ahtheerr, Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x005a41af" Value="4d31f6488d1d375c3a00488d7b04e88e00000085c0740e8b3383feff740789c7e82c121a0049ffc64983fe0874454883c320ebd64831db803c1a00740548ffc3ebf58a5c1aff80fb2f7407e831e81900eb05e8daf91900e98e000000"/>
+            <Line Type="bytes" Address="0x005a4294" Value="e94affffff"/>
+            <Line Type="bytes" Address="0x00949df0" Value="ff0000102f646174612f7034642f62696e642f00"/>
+            <Line Type="bytes" Address="0x00949e10" Value="fe0000102f646174612f7034642f6d6f642e63706b00"/>
+            <Line Type="bytes" Address="0x00949e30" Value="fd0000102f646174612f7034642f6d6f64312e63706b0000"/>
+            <Line Type="bytes" Address="0x00949e50" Value="fc0000102f646174612f7034642f6d6f64322e63706b0000"/>
+            <Line Type="bytes" Address="0x00949e70" Value="fb0000102f646174612f7034642f6d6f64332e63706b0000"/>
+            <Line Type="bytes" Address="0x00949e90" Value="fa0000102f617070302f646174612f6d6f642e63706b0000"/>
+            <Line Type="bytes" Address="0x00949eb0" Value="ffffffff2f617070302f646174612f7073342e63706b0000"/>
+            <Line Type="bytes" Address="0x00949ed0" Value="ffffffff2f617070302f646174612f646174612e63706b00"/>
+            <Line Type="bytes" Address="0x00949ef4" Value="00000000000000000000000000"/>
+        </PatchList>
+    </Metadata>
+</Patch>

--- a/patches/xml/Persona5Dancing-Orbis.xml
+++ b/patches/xml/Persona5Dancing-Orbis.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA12380</ID>
+    </TitleID>
+    <Metadata Title="Persona 5: Dancing in Starlight"
+            Name="Mod Support"
+            Note="A port of zarroboogs patch. \nhttps://github.com/zarroboogs/ppp \n\nHighest to lowest load priority: \n1. /data/p5d/bind/ (loose files) \n2. /data/p5d/mod.cpk \n3. /data/p5d/mod1.cpk \n4. /data/p5d/mod2.cpk \n5. /data/p5d/mod3.cpk \n6. /app0/data/mod.cpk"
+            Author="zarroboogs, Ahtheerr, Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0060e34c" Value="4d31f64c8d256a6c4400498d7c2404e8c000000085c07410418b342483feff740789c7e89cf7190049ffc64983fe08747a4983c420ebd34831db803c1a00740548ffc3ebf58a5c1aff80fb2f7407e8a1cd1900eb05e84adf1900e9be000000"/>
+            <Line Type="bytes" Address="0x0060e464" Value="e91affffff"/>
+            <Line Type="bytes" Address="0x00a54fc0" Value="ff0000102f646174612f7035642f62696e642f00"/>
+            <Line Type="bytes" Address="0x00a54fe0" Value="fe0000102f646174612f7035642f6d6f642e63706b00"/>
+            <Line Type="bytes" Address="0x00a55000" Value="fd0000102f646174612f7035642f6d6f64312e63706b0000"/>
+            <Line Type="bytes" Address="0x00a55020" Value="fc0000102f646174612f7035642f6d6f64322e63706b0000"/>
+            <Line Type="bytes" Address="0x00a55040" Value="fb0000102f646174612f7035642f6d6f64332e63706b0000"/>
+            <Line Type="bytes" Address="0x00a55060" Value="fa0000102f617070302f646174612f6d6f642e63706b0000"/>
+            <Line Type="bytes" Address="0x00a55080" Value="ffffffff2f617070302f646174612f7073342e63706b0000"/>
+            <Line Type="bytes" Address="0x00a550a0" Value="ffffffff2f617070302f646174612f646174612e63706b00"/>
+            <Line Type="bytes" Address="0x00a550c4" Value="00000000000000000000000000"/>
+        </PatchList>
+    </Metadata>
+</Patch>

--- a/patches/xml/Persona5Dancing-Orbis.xml
+++ b/patches/xml/Persona5Dancing-Orbis.xml
@@ -5,7 +5,7 @@
     </TitleID>
     <Metadata Title="Persona 5: Dancing in Starlight"
             Name="Mod Support"
-            Note="A port of zarroboogs patch. \nhttps://github.com/zarroboogs/ppp \n\nHighest to lowest load priority: \n1. /data/p5d/bind/ (loose files) \n2. /data/p5d/mod.cpk \n3. /data/p5d/mod1.cpk \n4. /data/p5d/mod2.cpk \n5. /data/p5d/mod3.cpk \n6. /app0/data/mod.cpk"
+            Note="A port of zarroboogs' patch. \nhttps://github.com/zarroboogs/ppp \n\nHighest to lowest load priority: \n1. /data/p5d/bind/ (loose files) \n2. /data/p5d/mod.cpk \n3. /data/p5d/mod1.cpk \n4. /data/p5d/mod2.cpk \n5. /data/p5d/mod3.cpk \n6. /app0/data/mod.cpk"
             Author="zarroboogs, Ahtheerr, Danu"
             PatchVer="1.0"
             AppVer="01.00"


### PR DESCRIPTION
This is a port of the mod support patches for these games from the xdelta format to the format used here. This makes things a lot more easier for me. I could only test the US versions for P3D and P5D and the EU version for P4D so the patches are set for those versions specifically.