### PR TITLE
Additional Title ID for Bloodborne.

### DIFF
--- a/patches/xml/Bloodborne-Orbis.xml
+++ b/patches/xml/Bloodborne-Orbis.xml
@@ -7,6 +7,7 @@
         <ID>CUSA00208</ID>
         <ID>CUSA01363</ID>
         <ID>CUSA03014</ID>
+        <ID>CUSA03023</ID>
     </TitleID>
     <Metadata Title="Bloodborne"
               Name="Skip Intro"


### PR DESCRIPTION
Just added Title ID "CUSA03023" to Bloodborne.

Tested 4 patches (Skip intro, Disable chromatic aberration, Disable motion blur, 60 FPS), worked fine.

Didn't test other patches but they should work as well.