### PR TITLE
Crash Team Racing Nitro-Fueled 1080p resolution patch for PS4 Pro users

### DIFF
--- a/patches/xml/CrashTeamRacingEU-Orbis.xml
+++ b/patches/xml/CrashTeamRacingEU-Orbis.xml
@@ -24,4 +24,14 @@
             <Line Type="bytes" Address="0x00ef0f52" Value="9090909090"/>
         </PatchList>
     </Metadata>
+    <Metadata Title="Crash Team Racing Nitro-Fueled"
+              Name="Resolution Patch (1080p for PS4 Pro)"
+              Author="TroyWarez"
+              PatchVer="1.0"
+              AppVer="01.21"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x017a9db3" Value="84"/>
+        </PatchList>
+    </Metadata>
 </Patch>

--- a/patches/xml/CrashTeamRacingUS-Orbis.xml
+++ b/patches/xml/CrashTeamRacingUS-Orbis.xml
@@ -24,4 +24,14 @@
             <Line Type="bytes" Address="0x00ef0f52" Value="9090909090"/>
         </PatchList>
     </Metadata>
+    <Metadata Title="Crash Team Racing Nitro-Fueled"
+              Name="Resolution Patch (1080p for PS4 Pro)"
+              Author="TroyWarez"
+              PatchVer="1.0"
+              AppVer="01.21"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x017a9db3" Value="84"/>
+        </PatchList>
+    </Metadata>
 </Patch>


### PR DESCRIPTION
I noticed that the 60 fps patch that illusion0001 made wasn't able reach a stable 60 fps+ during gameplay on a PS4 Pro. This patch forces the game to run at the native resolution for the base PS4 (which is 1080p vs 1440p on the Pro). 

In my testing, I have observed an fps increase of 20% to 30% depending upon the area. It only drops below 60 in the main hub area. The races are rock solid 60-80 fps at all times. 