### PR TITLE
Fixing typo in TheLastGuardian-Orbis.xml

### DIFF
--- a/patches/xml/TheLastGuardian-Orbis.xml
+++ b/patches/xml/TheLastGuardian-Orbis.xml
@@ -5,7 +5,7 @@
         <ID>CUSA03745</ID>
         <ID>CUSA04936</ID>
     </TitleID>
-    <Metadata Title="The Last Gurdian"
+    <Metadata Title="The Last Guardian"
               Name="60 FPS Unlock"
               Note="CPU Limited, for use with PS5."
               Author="illusion"
@@ -16,7 +16,7 @@
             <Line Type="bytes" Address="0x01051467" Value="e9b3000000"/>
         </PatchList>
     </Metadata>
-    <Metadata Title="The Last Gurdian"
+    <Metadata Title="The Last Guardian"
               Name="Resolution Patch: Native 3840x2160"
               Note="GPU Limited, for use with PS5."
               Author="illusion"


### PR DESCRIPTION
I was looking at the 4K patch to create a 720p patch for shadPS4 and I noticed there was a typo in the Title.